### PR TITLE
Fix UnsupportedAddressTypeException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     implementation "io.grpc:grpc-core:1.47.0"
     implementation "io.grpc:grpc-stub:1.47.0"
-    implementation "io.grpc:grpc-netty:1.47.0"
+    implementation "io.grpc:grpc-netty-shaded:1.47.0"
     implementation fileTree(dir: LOGSTASH_CORE_PATH, include: "**/logstash-core-?.*.*.jar")
 
     testImplementation 'junit:junit:4.13.2'

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
@@ -1,6 +1,8 @@
 package me.dinowernli.grpc.polyglot.grpc;
 
 import java.io.File;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,12 +49,13 @@ public class ChannelFactory {
   }
 
   private NettyChannelBuilder createChannelBuilder(HostAndPort endpoint) {
+    SocketAddress address = new InetSocketAddress(endpoint.getHost(), endpoint.getPort());
     if (!useTls) {
-      return NettyChannelBuilder.forAddress(endpoint.getHost(), endpoint.getPort())
+      return NettyChannelBuilder.forAddress(address)
           .negotiationType(NegotiationType.PLAINTEXT)
           .intercept(metadataInterceptor());
     } else {
-      return NettyChannelBuilder.forAddress(endpoint.getHost(), endpoint.getPort())
+      return NettyChannelBuilder.forAddress(address)
           .sslContext(createSslContext())
           .negotiationType(NegotiationType.TLS)
           .intercept(metadataInterceptor());

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
@@ -13,11 +13,11 @@ import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.*;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NegotiationType;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NegotiationType;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 

--- a/src/test/kotlin/net/p1kachu/logstash/input/grpc/TestServer.kt
+++ b/src/test/kotlin/net/p1kachu/logstash/input/grpc/TestServer.kt
@@ -2,7 +2,7 @@ package net.p1kachu.logstash.input.grpc
 
 import com.google.protobuf.ByteString
 import io.grpc.Server
-import io.grpc.netty.NettyServerBuilder
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import io.grpc.stub.StreamObserver
 import net.p1kachu.proto.hellostreamingworld.Hello
 import net.p1kachu.proto.hellostreamingworld.MultiGreeterGrpc


### PR DESCRIPTION
this closes #49 

Since the release of  0.1.3 updated to grpc-java 1.47.0 (#37) , gRPC connections have been failing with UnsupportedAddressTypeException.

A service-discovery related change in the recent version of grpc-netty seems to be causing this strange behavior, but the root cause has not been identified.

 - With `grpc-netty`: 
 ```
java.nio.channels.UnsupportedAddressTypeException
at sun.nio.ch.Net.checkAddress(Net.java:128) ~[?:?]
at sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:673) ~[?:?]
at io.netty.util.internal.SocketUtils$3.run(SocketUtils.java:91) ~[logstash-input-grpc-0.1.3.jar:?]
at io.netty.util.internal.SocketUtils$3.run(SocketUtils.java:88) ~[logstash-input-grpc-0.1.3.jar:?]
at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
at io.netty.util.internal.SocketUtils.connect(SocketUtils.java:88) ~[logstash-input-grpc-0.1.3.jar:?]
```

 - With `grpc-netty-shaded`: 
 ```
io.grpc.netty.shaded.io.netty.channel.AbstractChannel$AnnotatedConnectException: connect(..) failed: Invalid argument: /localhost:50051
Caused by: java.net.ConnectException: connect(..) failed: Invalid argument
        at io.grpc.netty.shaded.io.netty.channel.unix.Errors.newConnectException0(Errors.java:155) ~[logstash-input-grpc-0.1.3.jar:?]
        at io.grpc.netty.shaded.io.netty.channel.unix.Errors.handleConnectErrno(Errors.java:128) ~[logstash-input-grpc-0.1.3.jar:?]
        at io.grpc.netty.shaded.io.netty.channel.unix.Socket.connect(Socket.java:312) ~[logstash-input-grpc-0.1.3.jar:?]
```

 - Use NameResolver compliant URI `NettyChannelBuilder.forTarget("dns:///localhost:50051")`
 ```
java.lang.IllegalArgumentException: cannot find a NameResolver for dns:///localhost:50051
```

To workaround the issue, temporarily suppress using service name resolution by specifying SocketAddress directly.
