### PR TITLE
Merge Service Descriptor files when creating shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 shadowJar {
     archiveClassifier = null
+    mergeServiceFiles()
 }
 
 apply plugin: 'com.google.protobuf'

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
@@ -1,8 +1,6 @@
 package me.dinowernli.grpc.polyglot.grpc;
 
 import java.io.File;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,13 +47,12 @@ public class ChannelFactory {
   }
 
   private NettyChannelBuilder createChannelBuilder(HostAndPort endpoint) {
-    SocketAddress address = new InetSocketAddress(endpoint.getHost(), endpoint.getPort());
     if (!useTls) {
-      return NettyChannelBuilder.forAddress(address)
+      return NettyChannelBuilder.forAddress(endpoint.getHost(), endpoint.getPort())
           .negotiationType(NegotiationType.PLAINTEXT)
           .intercept(metadataInterceptor());
     } else {
-      return NettyChannelBuilder.forAddress(address)
+      return NettyChannelBuilder.forAddress(endpoint.getHost(), endpoint.getPort())
           .sslContext(createSslContext())
           .negotiationType(NegotiationType.TLS)
           .intercept(metadataInterceptor());


### PR DESCRIPTION
This will fix #49 in a different way.

`META-INF/services/io.grpc.NameResolverProvider` before:
```
io.grpc.netty.shaded.io.grpc.netty.UdsNameResolverProvider
```

after:
```
io.grpc.netty.shaded.io.grpc.netty.UdsNameResolverProvider
io.grpc.internal.DnsNameResolverProvider
```

ref. #50, https://github.com/grpc/grpc-java/issues/9367