### PR TITLE
surpress warning message "inner class Companion conflicts with field of same name"

### DIFF
--- a/src/main/kotlin/net/p1kachu/logstash/input/grpc/Grpc.kt
+++ b/src/main/kotlin/net/p1kachu/logstash/input/grpc/Grpc.kt
@@ -143,7 +143,7 @@ class Grpc(private val id: String, config: Configuration, context: Context?) : I
         return id
     }
 
-    companion object {
+    companion object KtCompanion {
         @JvmField
         val PROTOSET_PATH: PluginConfigSpec<String?> = PluginConfigSpec.requiredStringSetting("protoset_path")
         @JvmField


### PR DESCRIPTION
While there is no behavioural problem, the following warning is logged each time the pipeline starts up:

```
/usr/share/logstash/vendor/local_gems/637888e6/logstash-input-grpc-0.3.0/lib/logstash/inputs/grpc.rb:11: warning: inner class "net.p1kachu.logstash.input.grpc.Grpc::Companion" conflicts with field of same name
```

Rename the companion class as it appears to conflict with the class name generated by JRuby.